### PR TITLE
Add Shooter subsystem

### DIFF
--- a/src/main/java/org/teamresistance/frc/subsystem/TimedCommand.java
+++ b/src/main/java/org/teamresistance/frc/subsystem/TimedCommand.java
@@ -1,0 +1,19 @@
+package org.teamresistance.frc.subsystem;
+
+import org.strongback.command.Command;
+import org.strongback.command.Requirable;
+
+public abstract class TimedCommand extends Command {
+
+  protected TimedCommand(double timeoutInSeconds, Requirable... requirements) {
+    super(timeoutInSeconds, requirements);
+  }
+
+  @Override
+  public final boolean execute() {
+    executeUntilTimeout();
+    return false;
+  }
+
+  protected abstract void executeUntilTimeout();
+}

--- a/src/main/java/org/teamresistance/frc/subsystem/shooter/FireShooter.java
+++ b/src/main/java/org/teamresistance/frc/subsystem/shooter/FireShooter.java
@@ -2,15 +2,60 @@ package org.teamresistance.frc.subsystem.shooter;
 
 import org.strongback.command.Command;
 import org.strongback.command.CommandGroup;
+import org.teamresistance.frc.subsystem.TimedCommand;
 
 public final class FireShooter extends CommandGroup {
 
   public FireShooter(Shooter shooter) {
     // TODO: in Robot.java, remember to only dispatch if the ball sensor returns true.
     sequentially(
-        Command.create(Shooter.CHARGE_UP_TIME, shooter::chargeUp),
-        Command.create(shooter::discharge),
-        Command.create(Shooter.RELOAD_TIME, shooter::reload)
+        new ChargeUp(shooter),
+        new Discharge(shooter),
+        new Reload(shooter)
     );
+  }
+
+  private final class ChargeUp extends TimedCommand {
+    private final Shooter shooter;
+
+    private ChargeUp(Shooter shooter) {
+      super(Shooter.CHARGE_UP_TIME, shooter);
+      this.setNotInterruptible();
+      this.shooter = shooter;
+    }
+
+    @Override
+    protected void executeUntilTimeout() {
+      shooter.chargeUp();
+    }
+  }
+
+  private final class Discharge extends Command {
+    private final Shooter shooter;
+
+    private Discharge(Shooter shooter) {
+      this.shooter = shooter;
+    }
+
+    @Override
+    public boolean execute() {
+      shooter.discharge();
+      return true; // immediately finish
+    }
+  }
+
+  private final class Reload extends TimedCommand {
+    private final Shooter shooter;
+
+    private Reload(Shooter shooter) {
+      super(Shooter.RELOAD_TIME, shooter);
+      this.setNotInterruptible();
+      this.shooter = shooter;
+    }
+
+    @Override
+    protected void executeUntilTimeout() {
+      shooter.reload();
+    }
   }
 }

--- a/src/main/java/org/teamresistance/frc/subsystem/shooter/FireShooter.java
+++ b/src/main/java/org/teamresistance/frc/subsystem/shooter/FireShooter.java
@@ -1,0 +1,16 @@
+package org.teamresistance.frc.subsystem.shooter;
+
+import org.strongback.command.Command;
+import org.strongback.command.CommandGroup;
+
+public final class FireShooter extends CommandGroup {
+
+  public FireShooter(Shooter shooter) {
+    // TODO: in Robot.java, remember to only dispatch if the ball sensor returns true.
+    sequentially(
+        Command.create(Shooter.CHARGE_UP_TIME, shooter::chargeUp),
+        Command.create(shooter::discharge),
+        Command.create(Shooter.RELOAD_TIME, shooter::reload)
+    );
+  }
+}

--- a/src/main/java/org/teamresistance/frc/subsystem/shooter/Shooter.java
+++ b/src/main/java/org/teamresistance/frc/subsystem/shooter/Shooter.java
@@ -1,0 +1,34 @@
+package org.teamresistance.frc.subsystem.shooter;
+
+import org.strongback.command.Requirable;
+import org.strongback.components.Solenoid;
+
+public class Shooter implements Requirable {
+  static final double CHARGE_UP_TIME = 2.0; // seconds
+  static final double RELOAD_TIME = 0.3; // seconds
+
+  private final Solenoid trigger;
+  private final Solenoid shooter;
+
+  public Shooter(Solenoid trigger, Solenoid shooter) {
+    this.trigger = trigger;
+    this.shooter = shooter;
+  }
+
+  void chargeUp() {
+    trigger.extend();
+  }
+
+  void discharge() {
+    if (trigger.isExtending()) {
+      shooter.extend();
+    } else {
+      System.out.println("Ignoring discharge: must extend trigger before firing");
+    }
+  }
+
+  void reload() {
+    trigger.retract();
+    shooter.retract();
+  }
+}


### PR DESCRIPTION
I created a composite command that queues up the Fist of Death sequence: charge up, discharge, and then "reload".

We still have to remember to check the ball sensor before dispatching the command, but I think the subsystem itself is good to go. Here's the [original implementation](https://github.com/teamresistance/fist-of-death/blob/master/src/com/team86/mecanum/FistOfDeath.java) for reference.

@teamresistance/fist-of-life, thoughts on the new implementation? I don't feel great about leaving the ball sensor as a responsibility for the caller, but it also feels wrong to couple it to the Shooter so this is what I came up with. Feel free to 🔥 .