### PR TITLE
Add preliminary autonomous driving/strafing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,8 +32,8 @@ dependencies {
     compile wpilib()
     
     // Unit testing!
-    testCompile 'org.junit.jupiter:junit-jupiter-api:5.0.0-M2'
-    testCompile 'org.junit.jupiter:junit-jupiter-engine:5.0.0-M2'
+    testCompile 'org.junit.jupiter:junit-jupiter-api:5.0.0-M3'
+    testCompile 'org.junit.jupiter:junit-jupiter-engine:5.0.0-M3'
     testCompile 'org.assertj:assertj-core:3.5.2'
     testCompile 'org.mockito:mockito-core:2.2.22'
 }

--- a/src/main/java/org/teamresistance/frc/Robot.java
+++ b/src/main/java/org/teamresistance/frc/Robot.java
@@ -3,12 +3,17 @@ package org.teamresistance.frc;
 import org.strongback.Strongback;
 import org.strongback.SwitchReactor;
 import org.strongback.command.Command;
+import org.strongback.command.CommandGroup;
 import org.strongback.components.ui.FlightStick;
 import org.strongback.hardware.Hardware;
 import org.teamresistance.frc.command.HoldAngleCommand;
+import org.teamresistance.frc.command.StrafeCommand;
 import org.teamresistance.frc.subsystem.drive.Drive;
 
+import java.util.concurrent.TimeUnit;
+
 import edu.wpi.first.wpilibj.IterativeRobot;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 
 /**
  * Main robot class. Override methods from {@link IterativeRobot} to define behavior.
@@ -36,6 +41,21 @@ public class Robot extends IterativeRobot {
     // Hold the current angle of the robot while the trigger is held
     reactor.onTriggeredSubmit(leftJoystick.getTrigger(), () -> new HoldAngleCommand(drive, 90));
     reactor.onUntriggeredSubmit(leftJoystick.getTrigger(), () -> Command.cancel(drive));
+
+    // Drive straight, strafe 90 degrees, and strafe 45 -- each for 2 seconds
+    reactor.onTriggeredSubmit(leftJoystick.getButton(6), () -> new StrafeCommand(drive, 0, 1.5));
+    reactor.onTriggeredSubmit(leftJoystick.getButton(11), () -> new StrafeCommand(drive, 90, 1.5));
+    reactor.onTriggeredSubmit(leftJoystick.getButton(10), () -> new StrafeCommand(drive, 45, 1.5));
+
+    // Drive straight, pause for 2s, then strafe 90 degrees
+    reactor.onTriggeredSubmit(leftJoystick.getButton(7), () -> CommandGroup.runSequentially(
+        new StrafeCommand(drive, 0, 1.5),
+        Command.pause(2, TimeUnit.SECONDS), // TODO replace with full stop
+        new StrafeCommand(drive, 90, 1.5)
+    ));
+
+    // Cancel ongoing Drive commands. The interrupted commands should hand back operator control
+    reactor.onTriggered(leftJoystick.getButton(3), () -> Strongback.submit(Command.cancel(drive)));
   }
 
   @Override
@@ -50,7 +70,11 @@ public class Robot extends IterativeRobot {
 
   @Override
   public void teleopPeriodic() {
-    Pose pose = new Pose(IO.gyro.getAngle());
+    // Post our orientation on the SD for debugging purposes
+    double orientation = IO.gyro.getAngle();
+    SmartDashboard.putNumber("Gyro Angle", orientation);
+
+    Pose pose = new Pose(orientation);
     drive.onUpdate(pose);
   }
 

--- a/src/main/java/org/teamresistance/frc/command/ControllerCommand.java
+++ b/src/main/java/org/teamresistance/frc/command/ControllerCommand.java
@@ -5,6 +5,15 @@ import org.strongback.command.Requirable;
 import org.teamresistance.frc.subsystem.ClosedLooping;
 import org.teamresistance.frc.subsystem.Controller;
 
+/**
+ * This abstract class makes it easy to create a {@link Command} that sets a {@link Controller} on a
+ * subsystem by managing the lifecycle of the controller.
+ *
+ * @author Rothanak So
+ * @see HoldAngleCommand
+ * @see StrafeCommand
+ */
+// Human-readable version: class ControllerCommand<Subsystem, Controller, Signal> extends Command
 abstract class ControllerCommand<T extends ClosedLooping<V> & Requirable, U extends
     Controller<V>, V> extends Command {
   private final T subsystem;

--- a/src/main/java/org/teamresistance/frc/command/ControllerCommand.java
+++ b/src/main/java/org/teamresistance/frc/command/ControllerCommand.java
@@ -1,0 +1,50 @@
+package org.teamresistance.frc.command;
+
+import org.strongback.command.Command;
+import org.strongback.command.Requirable;
+import org.teamresistance.frc.subsystem.ClosedLooping;
+import org.teamresistance.frc.subsystem.Controller;
+
+abstract class ControllerCommand<T extends ClosedLooping<V> & Requirable, U extends
+    Controller<V>, V> extends Command {
+  private final T subsystem;
+  private final U controller;
+  private final boolean dontFinish;
+
+  ControllerCommand(T subsystem, U controller, boolean dontFinish) {
+    super(subsystem);
+    this.subsystem = subsystem;
+    this.controller = controller;
+    this.dontFinish = dontFinish;
+  }
+
+  ControllerCommand(T subsystem, U controller, double timeoutSeconds) {
+    super(timeoutSeconds, subsystem);
+    this.subsystem = subsystem;
+    this.controller = controller;
+    this.dontFinish = false;
+  }
+
+  @Override
+  public void initialize() {
+    subsystem.setController(controller);
+  }
+
+  @Override
+  public boolean execute() {
+    // Finish the command only if the controller is on target and the command isn't set to run
+    // indefinitely. If the Command has a timeout, Strongback will ignore the return value.
+    return !dontFinish && controller.isOnTarget();
+  }
+
+  @Override
+  public void interrupted() {
+    end();
+  }
+
+  @Override
+  public void end() {
+    // Hand back operator control
+    subsystem.setOpenLoop();
+  }
+}

--- a/src/main/java/org/teamresistance/frc/command/HoldAngleCommand.java
+++ b/src/main/java/org/teamresistance/frc/command/HoldAngleCommand.java
@@ -13,33 +13,10 @@ import org.teamresistance.frc.subsystem.drive.DriveHoldingAngleController;
  *
  * @author Rothanak So
  */
-public class HoldAngleCommand extends Command {
-  private final Drive drive;
-  private final DriveHoldingAngleController controller;
+public class HoldAngleCommand extends ControllerCommand<Drive, DriveHoldingAngleController, Drive.Signal> {
 
   public HoldAngleCommand(Drive drive, double targetAngle) {
-    super(drive);
-    this.drive = drive;
-    this.controller = new DriveHoldingAngleController(targetAngle);
-  }
-
-  @Override
-  public void initialize() {
-    drive.setController(controller);
-  }
-
-  @Override
-  public boolean execute() {
-    return false; // Unlike a TurnToAngle command, we want HoldAngle to run indefinitely.
-  }
-
-  @Override
-  public void interrupted() {
-    end();
-  }
-
-  @Override
-  public void end() {
-    drive.setOpenLoop();
+    // Unlike a TurnToAngle command, we want HoldAngle to run indefinitely.
+    super(drive, new DriveHoldingAngleController(targetAngle), true);
   }
 }

--- a/src/main/java/org/teamresistance/frc/command/StrafeCommand.java
+++ b/src/main/java/org/teamresistance/frc/command/StrafeCommand.java
@@ -1,0 +1,11 @@
+package org.teamresistance.frc.command;
+
+import org.teamresistance.frc.subsystem.drive.Drive;
+import org.teamresistance.frc.subsystem.drive.DriveStrafingController;
+
+public class StrafeCommand extends ControllerCommand<Drive, DriveStrafingController, Drive.Signal> {
+
+  public StrafeCommand(Drive drive, double heading, double timeoutSeconds) {
+    super(drive, new DriveStrafingController(heading), timeoutSeconds);
+  }
+}

--- a/src/main/java/org/teamresistance/frc/command/StrafeCommand.java
+++ b/src/main/java/org/teamresistance/frc/command/StrafeCommand.java
@@ -5,7 +5,7 @@ import org.teamresistance.frc.subsystem.drive.DriveStrafingController;
 
 public class StrafeCommand extends ControllerCommand<Drive, DriveStrafingController, Drive.Signal> {
 
-  public StrafeCommand(Drive drive, double heading, double timeoutSeconds) {
-    super(drive, new DriveStrafingController(heading), timeoutSeconds);
+  public StrafeCommand(Drive drive, double headingDeg, double timeoutSeconds) {
+    super(drive, new DriveStrafingController(headingDeg), timeoutSeconds);
   }
 }

--- a/src/main/java/org/teamresistance/frc/subsystem/drive/Drive.java
+++ b/src/main/java/org/teamresistance/frc/subsystem/drive/Drive.java
@@ -40,7 +40,7 @@ public class Drive extends ClosedLooping<Drive.Signal> implements Stoppable, Req
 
   public Drive(MecanumDrive robotDrive, ContinuousRange xSpeed, ContinuousRange ySpeed,
                ContinuousRange rotateSpeed) {
-    super(() -> new Signal(xSpeed.read(), ySpeed.read(), rotateSpeed.read()));
+    super(() -> Signal.createFieldOriented(xSpeed.read(), ySpeed.read(), rotateSpeed.read()));
     this.robotDrive = robotDrive;
   }
 
@@ -49,7 +49,7 @@ public class Drive extends ClosedLooping<Drive.Signal> implements Stoppable, Req
     if (signal.robotOriented) {
       // Convert the speeds from cartesian to polar
       double magnitude = Math.sqrt(signal.xSpeed * signal.xSpeed + signal.ySpeed * signal.ySpeed);
-      double direction = Math.atan2(signal.ySpeed, signal.xSpeed); // (y, x)
+      double direction = Math.toDegrees(Math.atan2(signal.ySpeed, signal.xSpeed));
       robotDrive.polar(magnitude, direction, signal.rotateSpeed);
     } else {
       robotDrive.cartesian(signal.xSpeed, signal.ySpeed, signal.rotateSpeed);
@@ -67,15 +67,21 @@ public class Drive extends ClosedLooping<Drive.Signal> implements Stoppable, Req
     final double rotateSpeed;
     final boolean robotOriented;
 
-    Signal(double xSpeed, double ySpeed, double rotateSpeed) {
-      this(xSpeed, ySpeed, rotateSpeed, false);
-    }
-
-    Signal(double xSpeed, double ySpeed, double rotateSpeed, boolean robotOriented) {
+    private Signal(double xSpeed, double ySpeed, double rotateSpeed, boolean robotOriented) {
       this.xSpeed = xSpeed;
       this.ySpeed = ySpeed;
       this.rotateSpeed = rotateSpeed;
       this.robotOriented = robotOriented;
+    }
+
+    static Signal createFieldOriented(double xSpeed, double ySpeed, double rotateSpeed) {
+      return new Signal(xSpeed, ySpeed, rotateSpeed, false);
+    }
+
+    static Signal createRobotOriented(double speed, double headingDeg, double rotateSpeed) {
+      double xSpeed = speed * Math.cos(Math.toRadians(headingDeg));
+      double ySpeed = speed * Math.sin(Math.toRadians(headingDeg));
+      return new Signal(xSpeed, ySpeed, rotateSpeed, true);
     }
   }
 }

--- a/src/main/java/org/teamresistance/frc/subsystem/drive/DriveHaltingController.java
+++ b/src/main/java/org/teamresistance/frc/subsystem/drive/DriveHaltingController.java
@@ -19,6 +19,7 @@ public final class DriveHaltingController implements Controller<Drive.Signal> {
 
   @Override
   public Drive.Signal computeSignal(Drive.Signal feedForward, Pose feedback) {
-    return new Drive.Signal(0, 0, 0);
+    // TODO: Spin the wheels inward instead to halt. May need some API tweaks.
+    return Drive.Signal.createFieldOriented(0, 0, 0);
   }
 }

--- a/src/main/java/org/teamresistance/frc/subsystem/drive/DriveStrafingController.java
+++ b/src/main/java/org/teamresistance/frc/subsystem/drive/DriveStrafingController.java
@@ -1,0 +1,22 @@
+package org.teamresistance.frc.subsystem.drive;
+
+import org.teamresistance.frc.Pose;
+import org.teamresistance.frc.subsystem.Controller;
+
+public class DriveStrafingController implements Controller<Drive.Signal> {
+  private static final double SPEED = 0.6;
+
+  private final Controller<Drive.Signal> angleController;
+  private final double directionDegrees;
+
+  public DriveStrafingController(double degrees) {
+    this.angleController = new DriveHoldingAngleController(0);
+    this.directionDegrees = degrees;
+  }
+
+  @Override
+  public Drive.Signal computeSignal(Drive.Signal feedForward, Pose feedback) {
+    double rotateSpeed = angleController.computeSignal(feedForward, feedback).rotateSpeed;
+    return Drive.Signal.createRobotOriented(SPEED, directionDegrees, rotateSpeed);
+  }
+}

--- a/src/main/java/org/teamresistance/frc/subsystem/drive/DriveStrafingController.java
+++ b/src/main/java/org/teamresistance/frc/subsystem/drive/DriveStrafingController.java
@@ -7,16 +7,16 @@ public class DriveStrafingController implements Controller<Drive.Signal> {
   private static final double SPEED = 0.6;
 
   private final Controller<Drive.Signal> angleController;
-  private final double directionDegrees;
+  private final double headingDeg;
 
-  public DriveStrafingController(double degrees) {
+  public DriveStrafingController(double headingDeg) {
     this.angleController = new DriveHoldingAngleController(0);
-    this.directionDegrees = degrees;
+    this.headingDeg = headingDeg;
   }
 
   @Override
   public Drive.Signal computeSignal(Drive.Signal feedForward, Pose feedback) {
     double rotateSpeed = angleController.computeSignal(feedForward, feedback).rotateSpeed;
-    return Drive.Signal.createRobotOriented(SPEED, directionDegrees, rotateSpeed);
+    return Drive.Signal.createRobotOriented(SPEED, headingDeg, rotateSpeed);
   }
 }

--- a/src/test/java/org/teamresistance/frc/subsystem/drive/DriveTest.java
+++ b/src/test/java/org/teamresistance/frc/subsystem/drive/DriveTest.java
@@ -22,12 +22,12 @@ class DriveTest {
   private final MecanumDrive robotDrive = new MecanumDrive(leftFront, leftRear, rightFront,
       rightRear, Mock.angleSensor());
 
-  // Drive is system-under-test (SUT), which includes the MecanumDrive dependency. We can treat
+  // Drive is the system-under-test (SUT), which includes the MecanumDrive dependency. We can treat
   // it as an isolated black box where its methods are the inputs and the motors are the outputs.
   private Drive drive = new Drive(robotDrive, () -> 0, () -> 0, () -> 0);
 
   @Test
-  void onSignal_WithRobotOrientedSignal_ShouldDrivePolar() {
+  void robotOrientedSignalShouldDrivePolar() {
     final double magnitude = 0.5; // speed
     final double direction = 90; // degrees
     final double rotation = 0.5; // speed

--- a/src/test/java/org/teamresistance/frc/subsystem/drive/DriveTest.java
+++ b/src/test/java/org/teamresistance/frc/subsystem/drive/DriveTest.java
@@ -1,0 +1,63 @@
+package org.teamresistance.frc.subsystem.drive;
+
+import org.junit.jupiter.api.Test;
+import org.strongback.components.Motor;
+import org.strongback.drive.MecanumDrive;
+import org.strongback.mock.Mock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DriveTest {
+  // Mock motors allow us to verify the motor outputs are correct without needing the actual
+  // hardware. The speed of the motor is stored in memory for later retrieval by getSpeed().
+  private final Motor leftFront = Mock.stoppedMotor();
+  private final Motor leftRear = Mock.stoppedMotor();
+  private final Motor rightFront = Mock.stoppedMotor();
+  private final Motor rightRear = Mock.stoppedMotor();
+
+  // We're using a real MecanumDrive instance instead of a mock because the logic inside
+  // MecanumDrive is part of the system we're testing. It's in an instance field rather than
+  // being inlined to allow us to directly call robotDrive.cartesian()/polar() later and compare
+  // the results to calling drive.onSignal().
+  private final MecanumDrive robotDrive = new MecanumDrive(leftFront, leftRear, rightFront,
+      rightRear, Mock.angleSensor());
+
+  // Drive is system-under-test (SUT), which includes the MecanumDrive dependency. We can treat
+  // it as an isolated black box where its methods are the inputs and the motors are the outputs.
+  private Drive drive = new Drive(robotDrive, () -> 0, () -> 0, () -> 0);
+
+  @Test
+  void onSignal_WithRobotOrientedSignal_ShouldDrivePolar() {
+    final double magnitude = 0.5; // speed
+    final double direction = 90; // degrees
+    final double rotation = 0.5; // speed
+
+    // Move the robot robot-oriented via our Drive subsystem
+    drive.onSignal(Drive.Signal.createRobotOriented(magnitude, direction, rotation));
+    double signaledLf = leftFront.getSpeed();
+    double signaledLr = leftRear.getSpeed();
+    double signaledRf = rightFront.getSpeed();
+    double signaledRr = rightRear.getSpeed();
+    resetMotors();
+
+    // Move the robot robot-oriented directly via the library
+    robotDrive.polar(magnitude, direction, rotation);
+    double directLf = leftFront.getSpeed();
+    double directLr = leftRear.getSpeed();
+    double directRf = rightFront.getSpeed();
+    double directRr = rightRear.getSpeed();
+
+    // Ensure our Drive subsystem properly forwarded the calls to the library
+    assertThat(signaledLf).isEqualTo(directLf);
+    assertThat(signaledLr).isEqualTo(directLr);
+    assertThat(signaledRf).isEqualTo(directRf);
+    assertThat(signaledRr).isEqualTo(directRr);
+  }
+
+  private void resetMotors() {
+    leftFront.stop();
+    leftRear.stop();
+    rightFront.stop();
+    rightRear.stop();
+  }
+}


### PR DESCRIPTION
This PR **adds commands for driving straight, strafing at 90, strafing at 45, and then sequentially driving straight and strafing at 90**. I've also thrown in a command that cancels the currently-running Drive command.

The code should behave the same way as it did when we wrapped up the shift, with all the dirty hacks rewritten properly. The coasting problem still exists and will be addressed in a follow-up PR.

### Lessons learned
@ShreyaRavi discovered why our robot had been driving straight ~~into her chair~~ for all three angles: `Math.atan2` returns radians. We actually ran into the same problem for `Math.cos` and `Math.sin` but managed to catch that during the shift. I've written a regression test (software test) in `DriveTest` that verified the robot-oriented driving works as intended now.

We do code reviews for this very reason. And as we add more math and boolean logic to our code, I'll be writing more unit tests before they become regression tests too. A 15-minute investment can save us 2 hours or more of troubleshooting.