### PR TITLE
Implement the DaveKnob for teleoperated rotation

### DIFF
--- a/src/main/java/org/teamresistance/frc/Robot.java
+++ b/src/main/java/org/teamresistance/frc/Robot.java
@@ -13,6 +13,7 @@ import org.teamresistance.frc.command.SnorfleReverseCommand;
 import org.teamresistance.frc.command.SnorfleStopReversingCommand;
 import org.teamresistance.frc.command.SnorfleToggleCommand;
 import org.teamresistance.frc.subsystem.climb.Climber;
+import org.teamresistance.frc.hid.DaveKnob;
 import org.teamresistance.frc.subsystem.drive.Drive;
 import org.teamresistance.frc.subsystem.snorfler.Snorfler;
 
@@ -29,14 +30,15 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 public class Robot extends IterativeRobot {
   private final FlightStick leftJoystick = Hardware.HumanInterfaceDevices.logitechAttack3D(0);
   private final FlightStick rightJoystick = Hardware.HumanInterfaceDevices.logitechAttack3D(1);
-  private final FlightStick coJoystick = Hardware.HumanInterfaceDevices.logitechAttack3D(2);
+  private final FlightStick coDriverBox = Hardware.HumanInterfaceDevices.logitechAttack3D(2);
+  private final DaveKnob knob = new DaveKnob(() -> coDriverBox.getAxis(2).read() * -180 + 180, IO.gyro);
 
   private final Snorfler snorfler = new Snorfler(IO.snorflerMotor);
   private final Drive drive = new Drive(
       IO.robotDrive,
       leftJoystick.getRoll(),
       leftJoystick.getPitch(),
-      rightJoystick.getRoll()
+      knob
   );
   private final Climber climber = new Climber(IO.climberMotor, IO.pdp, IO.CLIMBER_CHANNEL);
 
@@ -129,9 +131,10 @@ public class Robot extends IterativeRobot {
 
   @Override
   public void teleopPeriodic() {
-    // Post our orientation on the SD for debugging purposes
+    // Post values to the SmartDashboard for debugging
     double orientation = IO.gyro.getAngle();
     SmartDashboard.putNumber("Gyro Angle", orientation);
+    SmartDashboard.putNumber("Knob Angle", knob.read());
 
     Feedback feedback = new Feedback(orientation);
     drive.onUpdate(feedback);

--- a/src/main/java/org/teamresistance/frc/Robot.java
+++ b/src/main/java/org/teamresistance/frc/Robot.java
@@ -4,6 +4,7 @@ import org.strongback.Strongback;
 import org.strongback.SwitchReactor;
 import org.strongback.command.Command;
 import org.strongback.command.CommandGroup;
+import org.strongback.components.AngleSensor;
 import org.strongback.components.ui.FlightStick;
 import org.strongback.hardware.Hardware;
 import org.teamresistance.frc.command.BrakeCommand;
@@ -31,7 +32,8 @@ public class Robot extends IterativeRobot {
   private final FlightStick leftJoystick = Hardware.HumanInterfaceDevices.logitechAttack3D(0);
   private final FlightStick rightJoystick = Hardware.HumanInterfaceDevices.logitechAttack3D(1);
   private final FlightStick coDriverBox = Hardware.HumanInterfaceDevices.logitechAttack3D(2);
-  private final DaveKnob knob = new DaveKnob(() -> coDriverBox.getAxis(2).read() * -180 + 180, IO.gyro);
+  private final AngleSensor rawKnob = () -> coDriverBox.getAxis(2).read() * -180 + 180;
+  private final DaveKnob knob = new DaveKnob(rawKnob, IO.gyro);
 
   private final Snorfler snorfler = new Snorfler(IO.snorflerMotor);
   private final Drive drive = new Drive(
@@ -133,8 +135,10 @@ public class Robot extends IterativeRobot {
   public void teleopPeriodic() {
     // Post values to the SmartDashboard for debugging
     double orientation = IO.gyro.getAngle();
+
     SmartDashboard.putNumber("Gyro Angle", orientation);
-    SmartDashboard.putNumber("Knob Angle", knob.read());
+    SmartDashboard.putNumber("Knob Angle", rawKnob.getAngle());
+    SmartDashboard.putNumber("Computed Rotation Speed", knob.read());
 
     Feedback feedback = new Feedback(orientation);
     drive.onUpdate(feedback);

--- a/src/main/java/org/teamresistance/frc/hid/DaveKnob.java
+++ b/src/main/java/org/teamresistance/frc/hid/DaveKnob.java
@@ -25,14 +25,17 @@ public final class DaveKnob implements ContinuousRange {
       final double gyroAngle = gyro.getAngle();
 
       // Don't rotate if the shortest distance between the two angles is too large
-      if (Math.abs(knobAngle - gyroAngle + 180) % 360 - 180 > DEADBAND_DEGREES)
-        return 0;
+      //double v = Math.abs(knobAngle - gyroAngle + 180) % 360 - 180;
+      //SmartDashboard.putNumber("Knob-Gyro Difference", v);
+      //if (v > DEADBAND_DEGREES) {
+      //  return 0;
+      //}
 
       currentRotationPid = new SynchronousPID(SoftwarePIDController
-          .SourceType.RATE, 0.015, 0, 0)
+          .SourceType.RATE, 0.010, 0, 0)
           .withConfigurations(controller -> controller
               .withInputRange(0, 360) // gyro
-              .withOutputRange(-1.0, 1.0) // motor
+              .withOutputRange(-0.5, 0.5) // motor
               .withTarget(knobAngle) // degrees
               .withTolerance(2) // degrees
               .continuousInputs(true));

--- a/src/main/java/org/teamresistance/frc/hid/DaveKnob.java
+++ b/src/main/java/org/teamresistance/frc/hid/DaveKnob.java
@@ -1,0 +1,43 @@
+package org.teamresistance.frc.hid;
+
+import org.strongback.components.AngleSensor;
+import org.strongback.components.ui.ContinuousRange;
+import org.strongback.control.SoftwarePIDController;
+import org.teamresistance.frc.util.SynchronousPID;
+
+public final class DaveKnob implements ContinuousRange {
+  private static final double DEADBAND_DEGREES = 30.0;
+  private final AngleSensor knob;
+  private final AngleSensor gyro;
+
+  private SynchronousPID currentRotationPid;
+
+  public DaveKnob(AngleSensor knob, AngleSensor gyro) {
+    this.knob = knob;
+    this.gyro = gyro;
+  }
+
+  @Override
+  public double read() {
+    // Only update the setpoint when the robot isn't already in the middle of rotating
+    if (currentRotationPid == null || currentRotationPid.isWithinTolerance()) {
+      final double knobAngle = knob.getAngle();
+      final double gyroAngle = gyro.getAngle();
+
+      // Don't rotate if the shortest distance between the two angles is too large
+      if (Math.abs(knobAngle - gyroAngle + 180) % 360 - 180 > DEADBAND_DEGREES)
+        return 0;
+
+      currentRotationPid = new SynchronousPID(SoftwarePIDController
+          .SourceType.RATE, 0.015, 0, 0)
+          .withConfigurations(controller -> controller
+              .withInputRange(0, 360) // gyro
+              .withOutputRange(-1.0, 1.0) // motor
+              .withTarget(knobAngle) // degrees
+              .withTolerance(2) // degrees
+              .continuousInputs(true));
+    }
+
+    return currentRotationPid.calculate(gyro.getAngle());
+  }
+}

--- a/src/test/java/org/teamresistance/frc/hid/DaveKnobTest.java
+++ b/src/test/java/org/teamresistance/frc/hid/DaveKnobTest.java
@@ -1,0 +1,23 @@
+package org.teamresistance.frc.hid;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DaveKnobTest {
+
+  @Test
+  void whenInputOutsideDeadband_ShouldReturnZero() {
+    // Robot needs to correct +40deg
+    DaveKnob knob = new DaveKnob(() -> 40, () -> 0);
+    assertThat(knob.read()).isZero();
+  }
+
+  @Test
+  void whenInputNearFeedback_ShouldUseShortestDistance() {
+    // Robot needs to correct -10deg
+    DaveKnob knob1 = new DaveKnob(() -> 350, () -> 0);
+    DaveKnob knob2 = new DaveKnob(() -> 170, () -> 180);
+    assertThat(knob1.read()).isEqualTo(knob2.read());
+  }
+}


### PR DESCRIPTION
Here's the code for the rotation knob requested by Dave™. It's used to supply the setpoint for our orientation, which I've verified from looking at the [code from 2015](https://github.com/teamresistance/recycle-rush/blob/master/src/org/teamResistance/robot15/MecanumDrive.java#L53). The intent is to use it in place of the second Joystick, or so we think.

## Code

The knob behaves the exact same as the old knob code:
* It doesn't set a new setpoint until the robot has rotated to match the last one.
* It uses a deadband to ignore disparities larger than 30 degrees.
* It calculates the shortest distance to the setpoint ("fastpath").
* It uses a simple proportional loop with a kP of 0.015.
* **Bonus**: The math is unit-tested.

Patent pending.

We still need to implement the Joystick button overrides for orienting 0/90/180/270. We *may* be able to implement them as Controllers that suppress the `rotationSpeed` feedforwards; when these Controllers become inactive, control will default to the knob. I'll look into it soon. For now I'd like to test the knob as-is.

---

By some stroke of luck, I was able to integrate the knob into the control system without modifying any of the existing Drive subsystem code. The control loop design pulled through for us. Really cool.